### PR TITLE
SONARPMD-59 Deprecate rule LoosePackageCoupling in favor of "ArchitecturalConstraint"

### DIFF
--- a/src/main/resources/org/sonar/l10n/pmd/rules/pmd/LoosePackageCoupling.html
+++ b/src/main/resources/org/sonar/l10n/pmd/rules/pmd/LoosePackageCoupling.html
@@ -9,3 +9,7 @@ public class Bar {
    DontUseThisClass boo = new DontUseThisClass();
 }
 </pre>
+
+<p>
+   This rule is deprecated, use {rule:squid:ArchitecturalConstraint} instead.
+</p>

--- a/src/main/resources/org/sonar/plugins/pmd/rules.xml
+++ b/src/main/resources/org/sonar/plugins/pmd/rules.xml
@@ -1513,6 +1513,7 @@
   <rule key="LoosePackageCoupling">
     <priority>MAJOR</priority>
     <configKey><![CDATA[rulesets/java/coupling.xml/LoosePackageCoupling]]></configKey>
+    <status>DEPRECATED</status>
   </rule>
 
   <rule key="AvoidProtectedMethodInFinalClassNotExtending">


### PR DESCRIPTION
https://jira.sonarsource.com/browse/SONARPMD-59